### PR TITLE
Autoupdate potfiles

### DIFF
--- a/.github/workflows/pot-file-update.yaml
+++ b/.github/workflows/pot-file-update.yaml
@@ -2,6 +2,7 @@ name: Automate pot file creation
 on:
   schedule:
     - cron: 0 0 * * *
+  workflow_dispatch:
 
 jobs:
   master-update-pot-file:

--- a/.github/workflows/pot-file-update.yaml
+++ b/.github/workflows/pot-file-update.yaml
@@ -1,0 +1,33 @@
+name: Automate pot file creation
+on:
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  master-update-pot-file:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout anaconda
+        uses: actions/checkout@v2
+        with:
+          path: anaconda
+          repository: rhinstaller/anaconda
+          ref: master-adjust-for-po-push-automation
+      - name: Create pot file
+        uses: rhinstaller/anaconda-make-executor-action@v1-beta2
+        with:
+          make-command: pot-update-check
+          path: anaconda
+      - name: Checkout anaconda-l10n
+        uses: actions/checkout@v2
+        with:
+          path: anaconda-l10n
+      - name: Push new potfile
+        run: |
+          cp -v anaconda/po/anaconda.pot anaconda-l10n/master/
+          cd anaconda-l10n
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m "update pot-file"
+          git push

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # anaconda-l10n
 Anaconda localization repository for Weblate translation platform.
 
+![Automatic pot update](https://github.com/rhinstaller/anaconda-l10n/workflows/.github/workflows/pot-file-update.yaml/badge.svg)
+
 [![Translation status](https://translate.fedoraproject.org/widgets/anaconda/-/open-graph.png)](https://translate.fedoraproject.org/engage/anaconda/?utm_source=widget)


### PR DESCRIPTION
Use GitHub actions to automatically update pot files in the localization repository. It will daily update the pot file.
After test that this is working as expected I can add more jobs to cover other branches not just master.

I've created new GH action to get our dependencies and run makefile. You can find it here.

 https://github.com/rhinstaller/anaconda-make-executor-action

Badge can't be tested until first run of the action is done. If not working I'll fix it later.

Blocked by: https://github.com/rhinstaller/anaconda/pull/2830