### PR TITLE
Checkout correct branch with pot-file-update GH action

### DIFF
--- a/.github/workflows/pot-file-update.yaml
+++ b/.github/workflows/pot-file-update.yaml
@@ -13,7 +13,7 @@ jobs:
         with:
           path: anaconda
           repository: rhinstaller/anaconda
-          ref: master-adjust-for-po-push-automation
+          ref: master
       - name: Create pot file
         uses: rhinstaller/anaconda-make-executor-action@v1-beta2
         with:


### PR DESCRIPTION
I had it set to branch with necessary changes on Anaconda side but this branch is already merged now. Fix this in the configuration.