### PR TITLE
Apply pot-file-update action for multiple branches

### DIFF
--- a/.github/workflows/pot-file-update.yaml
+++ b/.github/workflows/pot-file-update.yaml
@@ -7,6 +7,8 @@ on:
 jobs:
   master-update-pot-file:
     strategy:
+      # only one job at once otherwise one job will push and second job will get conflict on remote
+      max-parallel: 1
       # update this matrix to support new Anaconda branches
       matrix:
         branch: [ master, f33 ]

--- a/.github/workflows/pot-file-update.yaml
+++ b/.github/workflows/pot-file-update.yaml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: anaconda-l10n
+          ref: master
       - name: Push new potfile
         run: |
           cp -v anaconda/po/anaconda.pot anaconda-l10n/${{ matrix.branch }}

--- a/.github/workflows/pot-file-update.yaml
+++ b/.github/workflows/pot-file-update.yaml
@@ -6,14 +6,29 @@ on:
 
 jobs:
   master-update-pot-file:
+    strategy:
+      # update this matrix to support new Anaconda branches
+      matrix:
+        branch: [ master, f33 ]
+
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout anaconda
+      # run this step only for Rawhide
+      - name: Checkout Rawhide anaconda
         uses: actions/checkout@v2
+        if: ${{ matrix.branch == 'master' }}
         with:
           path: anaconda
           repository: rhinstaller/anaconda
-          ref: master
+          ref: ${{ matrix.branch }}
+      # run this step only for branched Fedora
+      - name: Checkout branched fedora anaconda
+        uses: actions/checkout@v2
+        if: ${{ startsWith(matrix.branch, 'f') }}
+        with:
+          path: anaconda
+          repository: rhinstaller/anaconda
+          ref: ${{ matrix.branch }}-devel
       - name: Create pot file
         uses: rhinstaller/anaconda-make-executor-action@v1-beta2
         with:
@@ -25,7 +40,7 @@ jobs:
           path: anaconda-l10n
       - name: Push new potfile
         run: |
-          cp -v anaconda/po/anaconda.pot anaconda-l10n/master/
+          cp -v anaconda/po/anaconda.pot anaconda-l10n/${{ matrix.branch }}
           cd anaconda-l10n
           git config user.name github-actions
           git config user.email github-actions@github.com


### PR DESCRIPTION
This will have to be updated every time during Anaconda branching but it's still just one place to cover everything.

Right now this should update branches for Rawhide and Fedora-33.