### PR TITLE
Rename update-pot-file GH action job

### DIFF
--- a/.github/workflows/pot-file-update.yaml
+++ b/.github/workflows/pot-file-update.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  master-update-pot-file:
+  update-pot-file:
     strategy:
       # only one job at once otherwise one job will push and second job will get conflict on remote
       max-parallel: 1


### PR DESCRIPTION
It's not related only to master but also to Fedora and other branches.