### PR TITLE
Use our custom container only for creating pot file

### DIFF
--- a/.github/workflows/pot-file-update.yaml
+++ b/.github/workflows/pot-file-update.yaml
@@ -24,8 +24,6 @@ jobs:
             container-tag: master
 
     runs-on: ubuntu-latest
-    container:
-      image: docker://quay.io/rhinstaller/anaconda-ci:${{ matrix.container-tag }}
     steps:
       - name: Checkout anaconda ${{ matrix.anaconda-branch }}
         uses: actions/checkout@v2
@@ -35,13 +33,11 @@ jobs:
           ref: ${{ matrix.anaconda-branch }}
       - name: Create pot file
         run: |
-          echo "Creating pot file..."
-          pushd anaconda
-          ./autogen.sh
-          ./configure
-          make
-          make pot-update-check
-          popd
+          podman run --rm -v ./anaconda:/anaconda:Z --workdir /anaconda quay.io/rhinstaller/anaconda-ci:${{ matrix.container-tag }} sh -c " \
+          ./autogen.sh; \
+          ./configure; \
+          make; \
+          make pot-update-check"
       - name: Checkout anaconda-l10n
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Right now docker has some issue in our container with checkout action. Let's move our container only on the needed parts.

Similar problem is filed here https://github.com/actions/checkout/issues/560.