### PR TITLE
Remove duplicated header in kn.po

### DIFF
--- a/master/kn.po
+++ b/master/kn.po
@@ -32,7 +32,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);X-Generator: Zanata 3.5.1\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Zanata 4.6.2\n"
 
 #: pyanaconda/rescue.py:272


### PR DESCRIPTION
Resolves one of the HACKs in https://github.com/rhinstaller/anaconda/pull/3785.

(Perhaps we want to drop all Zanata headers? They should be useless metadata.)