### PR TITLE
Update localization from Fedora 36

### DIFF
--- a/.github/workflows/pot-file-update.yaml
+++ b/.github/workflows/pot-file-update.yaml
@@ -11,14 +11,14 @@ jobs:
       max-parallel: 1
       # update this matrix to support new Anaconda branches
       matrix:
-        branch: [ master, f35, rhel-9 ]
+        branch: [ master, f36, rhel-9 ]
         include:
           - branch: master
             anaconda-branch: master
             container-tag: master
-          - branch: f35
-            anaconda-branch: f35-devel
-            container-tag: f35-devel
+          - branch: f36
+            anaconda-branch: f36-devel
+            container-tag: f36-devel
           - branch: rhel-9
             anaconda-branch: rhel-9
             container-tag: master


### PR DESCRIPTION
We were still pointing to Fedora 35 instead so the translations were not updated on Weblate.