### PR TITLE
Retry push on pot updates fail

### DIFF
--- a/.github/workflows/pot-file-update.yaml
+++ b/.github/workflows/pot-file-update.yaml
@@ -51,4 +51,22 @@ jobs:
           git config user.email github-actions@github.com
           git add .
           git commit -m "update pot-file"
+
+          # do a 5 push retries in case weblate just pushed to the repository
+          # push from weblate could happen easily because webhook updates the translations
+          RETRIES=5
+          DELAY=2
+          COUNT=0
+          while [ $COUNT -lt $RETRIES ]; do
+          git pull --rebase
           git push
+          if [ $? -eq 0 ]; then
+              break
+              exit 0
+          fi
+          let COUNT=$COUNT+1
+          sleep $DELAY
+          done
+
+          # retries were not successful
+          exit 1


### PR DESCRIPTION
This could happen easily right now. We enabled webhooks for Weblate in this repository so now Weblate update translation files on an update. That is mostly fine for first two iterations of this GH Action matrix but it will fail on the third one.

What happens:
master -> pull
master -> push
weblate -> push master updates
fXX -> pull
fXX -> push
rhel-9 -> pull
weblate -> push fXX updates
rhel-9 -> push (FAIL because repository changed)

To solve this add retry for the push and try it 5 more times.