### PR TITLE
Do not update pot file if content didn't changed

### DIFF
--- a/.github/workflows/pot-file-update.yaml
+++ b/.github/workflows/pot-file-update.yaml
@@ -50,7 +50,16 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .
-          git commit -m "update pot-file"
+
+          # test if the potfile needs update
+          # If there is any change except line with POT-Creation-Date we should push new version
+          if ! git diff -I 'POT-Creation-Date:' --cached --quiet; then
+              echo "The pot file did not change."
+              exit 0
+          else
+              git diff --cached
+          fi
+          git commit -m "update ${{ matrix.branch }} pot-file"
 
           # do a 5 push retries in case weblate just pushed to the repository
           # push from weblate could happen easily because webhook updates the translations


### PR DESCRIPTION
We can find out if pot file did changed by looking on number of changed lines.
If 1 line changed that means no content did changed. Only creation date was updated.
If more than 1 line changed we have meaningful change of pot file.
Also add branch name to the commit description.

Tested here:
https://github.com/jkonecny12/anaconda-l10n/actions/runs/4363824633/jobs/7630389579

For some for me unknown reason `f37` branch is not working correctly. However, it works fine on `master` and `rhel-9`. In worse case scenario it will update pot file more often than necessary so I would be for merging this anyway.