### PR TITLE
Enable automated pot file creation for fedora-38

### DIFF
--- a/.github/workflows/pot-file-update.yaml
+++ b/.github/workflows/pot-file-update.yaml
@@ -11,14 +11,14 @@ jobs:
       max-parallel: 1
       # update this matrix to support new Anaconda branches
       matrix:
-        branch: [ master, f37, rhel-9 ]
+        branch: [ master, f38, rhel-9 ]
         include:
           - branch: master
             anaconda-branch: master
             container-tag: master
-          - branch: f37
-            anaconda-branch: f37-release
-            container-tag: f37-release
+          - branch: f38
+            anaconda-branch: fedora-38
+            container-tag: fedora-38
           - branch: rhel-9
             anaconda-branch: rhel-9
             container-tag: master


### PR DESCRIPTION
We missed pot file automation for Fedora 38. Let's fix it now.

Tested here: https://github.com/jkonecny12/anaconda-l10n/actions/runs/4363994136/jobs/7630766995