### PR TITLE
Fix broken ar localization - forbidden code point

### DIFF
--- a/master/ar.po
+++ b/master/ar.po
@@ -7079,10 +7079,6 @@ msgstr "{}. {}"
 #~ msgid "Disk \"{}\" given in nvdimm command does not exist."
 #~ msgstr "القرص \"{}\" المُعطى في أمر nvdimm غير موجود."
 
-#, fuzzy, python-brace-format
-#~ msgid "NVDIMM device {namespace}"
-#~ msgstr "جهاز NVDIMM ‫{namespace}"
-
 #~ msgid "Help!"
 #~ msgstr "مساعدة!"
 


### PR DESCRIPTION
In the Arabic po file there were (commented out) translation with forbidden code point.

As the result during the release rpminspect gave us error:

A forbidden code point, 0x202B, was found in the anaconda-40.18/po/ar.po source file on line 7050 at column 23. This source file is used by anaconda.spec.

Remove the commented out string from the ar.po file. The string was removed from Anaconda by [607aebec25d87aa2e2f290f8cd80aad0e7af8a21](https://github.com/rhinstaller/anaconda/commit/607aebec25d87aa2e2f290f8cd80aad0e7af8a21#diff-146828d286341c90730b200c8364a4612724c4f0d6532df95b17e9b1456b3d0fL468) I guess it's staying commented out by Weblate to help with other translations.

This should resolve: https://artifacts.dev.testing-farm.io/55d735a6-257e-4a35-b624-4cd7d429c8e6/