### PR TITLE
Enable rhel-10 container (+use public containers for rhel branches)

### DIFF
--- a/.github/workflows/pot-file-update.yaml
+++ b/.github/workflows/pot-file-update.yaml
@@ -21,7 +21,7 @@ jobs:
             container-tag: fedora-40
           - branch: rhel-9
             anaconda-branch: rhel-9
-            container-tag: master
+            container-tag: rhel-9
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pot-file-update.yaml
+++ b/.github/workflows/pot-file-update.yaml
@@ -22,6 +22,9 @@ jobs:
           - branch: rhel-9
             anaconda-branch: rhel-9
             container-tag: rhel-9
+          - branch: rhel-10
+            anaconda-branch: rhel-10
+            container-tag: rhel-10
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We migrated from RHEL branches to CentOS Stream which enables us to upload images to the public repository and use it here.

This PR is blocked by https://github.com/rhinstaller/anaconda/pull/5626.