### PR TITLE
Correct how rhel-10 branch is added to the matrix

### DIFF
--- a/.github/workflows/pot-file-update.yaml
+++ b/.github/workflows/pot-file-update.yaml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 1
       # update this matrix to support new Anaconda branches
       matrix:
-        branch: [ master, f40, rhel-9 ]
+        branch: [ master, f40, rhel-9, rhel-10 ]
         include:
           - branch: master
             anaconda-branch: master


### PR DESCRIPTION
It works even without this patch but it shows
(rhel-10, rhel-10, rhel-10) for each value in the include part.

Let's fix that.

Tested here: https://github.com/jkonecny12/anaconda-l10n/actions/runs/8938419403