### PR TITLE
Do not cancel the workflow on first failure

### DIFF
--- a/.github/workflows/pot-file-update.yaml
+++ b/.github/workflows/pot-file-update.yaml
@@ -9,6 +9,8 @@ jobs:
     strategy:
       # only one job at once otherwise one job will push and second job will get conflict on remote
       max-parallel: 1
+      # do not stop on the first failed branch
+      fail-fast: false
       # update this matrix to support new Anaconda branches
       matrix:
         branch: [ master, f40, rhel-9 ]


### PR DESCRIPTION
We don't want to block all the branches on failure of one branch.

Tested on https://github.com/jkonecny12/anaconda-l10n/actions/runs/8939711605/job/24556274908